### PR TITLE
Activity to launch service without any UI

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,6 +79,7 @@ dependencies {
 
     implementation(libs.androidx.hilt.navigation.compose)
     implementation(libs.hilt.android)
+    implementation(libs.androidx.appcompat)
     ksp(libs.hilt.compiler)
     ksp(libs.hilt.ksp)
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,11 @@
             </intent-filter>
         </activity>
 
-        <service
+        <activity
+            android:name=".shortcut.StartMouseShortcutActivity"
+            android:exported="true"
+            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
+            <service
             android:name=".service.MouseService"
             android:exported="false"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,24 +20,25 @@
             android:theme="@style/Theme.PenMouseS">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
 
-        <activity
-            android:name=".shortcut.StartMouseShortcutActivity"
-            android:exported="true"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar" />
-            <service
+        <receiver
+            android:name=".shortcuts.ToggleMouseReceiver"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="pl.jojczak.penmouses.action.TOGGLE_MOUSE_SERVICE" />
+            </intent-filter>
+        </receiver>
+
+        <service
             android:name=".service.MouseService"
             android:exported="false"
             android:permission="android.permission.BIND_ACCESSIBILITY_SERVICE">
-
             <intent-filter>
                 <action android:name="android.accessibilityservice.AccessibilityService" />
             </intent-filter>
-
             <meta-data
                 android:name="android.accessibilityservice"
                 android:resource="@xml/accessibility_service_config" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -13,6 +13,7 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.PenMouseS">
+
         <activity
             android:name=".ui.main.MainActivity"
             android:exported="true"
@@ -22,14 +23,17 @@
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
         </activity>
 
+        <activity
+            android:name=".shortcuts.StartMouseShortcutActivity" android:exported="true"
+            android:label="Toggle Mouse Proxy" android:icon="@mipmap/ic_launcher_round" android:theme="@android:style/Theme.NoDisplay"> </activity>
+
         <receiver
-            android:name=".shortcuts.ToggleMouseReceiver"
-            android:exported="true">
-            <intent-filter>
-                <action android:name="pl.jojczak.penmouses.action.TOGGLE_MOUSE_SERVICE" />
-            </intent-filter>
+            android:name=".shortcuts.ToggleMouseReceiver" android:exported="true"> <intent-filter>
+            <action android:name="pl.jojczak.penmouses.action.TOGGLE_MOUSE_SERVICE" />
+        </intent-filter>
         </receiver>
 
         <service

--- a/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
+++ b/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
@@ -1,18 +1,49 @@
-package pl.jojczak.penmouses.shortcut
+package pl.jojczak.penmouses.shortcuts
 
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.Context
 import android.os.Bundle
+import android.view.accessibility.AccessibilityManager
 import androidx.appcompat.app.AppCompatActivity
-import pl.jojczak.penmouses.service.AppToServiceEvent // Make sure this import is here
+import pl.jojczak.penmouses.service.AppToServiceEvent // Already imported
+import pl.jojczak.penmouses.service.MouseService // Import MouseService to get its class name
 
 class StartMouseShortcutActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        // This line sends the signal to start the mouse service
-        AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Start)
+        // Get the current status of the MouseService
+        val isMouseServiceActive = isAccessibilityServiceEnabled(
+            this,
+            MouseService::class.java.name // Get the fully qualified name of the service
+        )
 
-        // This makes the activity close immediately after sending the signal
+        // Toggle the service based on its current state
+        if (isMouseServiceActive) {
+            // If it's active, send the STOP event
+            AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Stop)
+        } else {
+            // If it's not active, send the START event
+            AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Start)
+        }
+
+        // Finish the activity immediately so it doesn't show a blank screen
         finish()
+    }
+
+    /**
+     * Helper function to check if a specific Accessibility Service is enabled.
+     */
+    private fun isAccessibilityServiceEnabled(context: Context, serviceClassName: String): Boolean {
+        val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        val enabledServices = accessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+
+        for (service in enabledServices) {
+            if (service.resolveInfo.serviceInfo.name == serviceClassName) {
+                return true
+            }
+        }
+        return false
     }
 }

--- a/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
+++ b/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
@@ -1,39 +1,60 @@
-package pl.jojczak.penmouses.shortcuts
+package pl.jojczak.penmouses.shortcuts // MAKE SURE THIS IS 'shortcuts' (plural)
 
 import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
+import android.provider.Settings // Import for launching settings
+import android.util.Log
 import android.view.accessibility.AccessibilityManager
 import androidx.appcompat.app.AppCompatActivity
-import pl.jojczak.penmouses.service.AppToServiceEvent // Already imported
-import pl.jojczak.penmouses.service.MouseService // Import MouseService to get its class name
+import pl.jojczak.penmouses.service.MouseService // Import MouseService
+
+// ACTION_TOGGLE_MOUSE_SERVICE is defined in ToggleMouseReceiver.kt and is a const val.
+// It will be accessible here due to being in the same package.
 
 class StartMouseShortcutActivity : AppCompatActivity() {
 
+    companion object {
+        private const val TAG = "StartToggleAct"
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        Log.d(TAG, "onCreate: StartMouseShortcutActivity launched.")
 
-        // Get the current status of the MouseService
-        val isMouseServiceActive = isAccessibilityServiceEnabled(
+        // 1. Check if the Accessibility Service is enabled in system settings
+        val isServiceEnabledInSettings = isAccessibilityServiceEnabled(
             this,
-            MouseService::class.java.name // Get the fully qualified name of the service
+            MouseService::class.java.name
         )
+        Log.d(TAG, "MouseService enabled in settings: $isServiceEnabledInSettings")
 
-        // Toggle the service based on its current state
-        if (isMouseServiceActive) {
-            // If it's active, send the STOP event
-            AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Stop)
+        if (!isServiceEnabledInSettings) {
+            // 2. If the service is NOT enabled in settings, open Accessibility Settings
+            Log.d(TAG, "Service not enabled in settings. Opening Accessibility Settings.")
+            val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
+            // Use NEW_TASK flag as we're starting an activity from a non-activity context (implicitly)
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            startActivity(intent)
+            // Optionally, you might want to show a Toast message here to guide the user
+            // Toast.makeText(this, "Please enable PenMouseS Accessibility Service", Toast.LENGTH_LONG).show()
         } else {
-            // If it's not active, send the START event
-            AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Start)
+            // 3. If the service IS enabled in settings, proceed with the toggle logic via broadcast
+            Log.d(TAG, "Service enabled in settings. Sending toggle broadcast.")
+            val toggleIntent = Intent(ACTION_TOGGLE_MOUSE_SERVICE).apply {
+                setPackage(this@StartMouseShortcutActivity.packageName)
+            }
+            sendBroadcast(toggleIntent)
+            Log.d(TAG, "Toggle broadcast sent.")
         }
 
-        // Finish the activity immediately so it doesn't show a blank screen
+        // Finish this activity immediately, regardless of what happened
         finish()
     }
 
     /**
-     * Helper function to check if a specific Accessibility Service is enabled.
+     * Helper function to check if a specific Accessibility Service is enabled by the user in settings.
      */
     private fun isAccessibilityServiceEnabled(context: Context, serviceClassName: String): Boolean {
         val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager

--- a/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
+++ b/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
@@ -1,0 +1,18 @@
+package pl.jojczak.penmouses.shortcut
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import pl.jojczak.penmouses.service.AppToServiceEvent // Make sure this import is here
+
+class StartMouseShortcutActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        // This line sends the signal to start the mouse service
+        AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Start)
+
+        // This makes the activity close immediately after sending the signal
+        finish()
+    }
+}

--- a/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
+++ b/app/src/main/java/pl/jojczak/penmouses/shortcuts/StartMouseShortcutActivity.kt
@@ -1,17 +1,17 @@
-package pl.jojczak.penmouses.shortcuts // MAKE SURE THIS IS 'shortcuts' (plural)
+package pl.jojczak.penmouses.shortcuts
 
-import android.accessibilityservice.AccessibilityServiceInfo
-import android.content.Context
 import android.content.Intent
 import android.os.Bundle
-import android.provider.Settings // Import for launching settings
 import android.util.Log
-import android.view.accessibility.AccessibilityManager
 import androidx.appcompat.app.AppCompatActivity
 import pl.jojczak.penmouses.service.MouseService // Import MouseService
+import pl.jojczak.penmouses.ui.main.MainActivity // Import MainActivity
+import android.view.accessibility.AccessibilityManager // For AccessibilityManager
+import android.accessibilityservice.AccessibilityServiceInfo // For AccessibilityServiceInfo
+import android.content.Context
+import android.provider.Settings // For Settings.ACTION_ACCESSIBILITY_SETTINGS
 
-// ACTION_TOGGLE_MOUSE_SERVICE is defined in ToggleMouseReceiver.kt and is a const val.
-// It will be accessible here due to being in the same package.
+const val EXTRA_MINIMIZE_APP = "extra_minimize_app" // Define a constant for the extra
 
 class StartMouseShortcutActivity : AppCompatActivity() {
 
@@ -31,31 +31,37 @@ class StartMouseShortcutActivity : AppCompatActivity() {
         Log.d(TAG, "MouseService enabled in settings: $isServiceEnabledInSettings")
 
         if (!isServiceEnabledInSettings) {
-            // 2. If the service is NOT enabled in settings, open Accessibility Settings
+            // If the service is NOT enabled in settings, open Accessibility Settings
             Log.d(TAG, "Service not enabled in settings. Opening Accessibility Settings.")
-            val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS)
-            // Use NEW_TASK flag as we're starting an activity from a non-activity context (implicitly)
+            val intent = Intent(Settings.ACTION_ACCESSIBILITY_SETTINGS) // Add android.provider.Settings import
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             startActivity(intent)
-            // Optionally, you might want to show a Toast message here to guide the user
-            // Toast.makeText(this, "Please enable PenMouseS Accessibility Service", Toast.LENGTH_LONG).show()
         } else {
-            // 3. If the service IS enabled in settings, proceed with the toggle logic via broadcast
+            // If the service IS enabled in settings, proceed with the toggle logic via broadcast
             Log.d(TAG, "Service enabled in settings. Sending toggle broadcast.")
             val toggleIntent = Intent(ACTION_TOGGLE_MOUSE_SERVICE).apply {
                 setPackage(this@StartMouseShortcutActivity.packageName)
             }
             sendBroadcast(toggleIntent)
             Log.d(TAG, "Toggle broadcast sent.")
+
+            // NOW, launch MainActivity with a flag to tell it to minimize
+            val mainActivityIntent = Intent(this, MainActivity::class.java).apply {
+                // This flag is crucial when starting an Activity from a context that isn't already an Activity (like from a BroadcastReceiver, or a proxy Activity that's immediately finishing)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                // This flag ensures that if MainActivity is already running, it's brought to the front and its onNewIntent() is called
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                // Add our custom extra to signal MainActivity to minimize itself
+                putExtra(EXTRA_MINIMIZE_APP, true)
+            }
+            startActivity(mainActivityIntent)
+            Log.d(TAG, "Launched MainActivity with minimize flag.")
         }
 
-        // Finish this activity immediately, regardless of what happened
+        // Finish this activity immediately.
         finish()
     }
 
-    /**
-     * Helper function to check if a specific Accessibility Service is enabled by the user in settings.
-     */
     private fun isAccessibilityServiceEnabled(context: Context, serviceClassName: String): Boolean {
         val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
         val enabledServices = accessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)

--- a/app/src/main/java/pl/jojczak/penmouses/shortcuts/ToggleMouseReceiver.kt
+++ b/app/src/main/java/pl/jojczak/penmouses/shortcuts/ToggleMouseReceiver.kt
@@ -1,0 +1,51 @@
+package pl.jojczak.penmouses.shortcuts
+
+import android.accessibilityservice.AccessibilityServiceInfo
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.view.accessibility.AccessibilityManager
+import pl.jojczak.penmouses.service.AppToServiceEvent
+import pl.jojczak.penmouses.service.MouseService // Import MouseService
+
+// Define a unique action string for your custom broadcast
+const val ACTION_TOGGLE_MOUSE_SERVICE = "pl.jojczak.penmouses.action.TOGGLE_MOUSE_SERVICE"
+
+class ToggleMouseReceiver : BroadcastReceiver() {
+
+    override fun onReceive(context: Context, intent: Intent) {
+        // Ensure this broadcast is for our intended action
+        if (intent.action == ACTION_TOGGLE_MOUSE_SERVICE) {
+            // Get the current status of the MouseService
+            val isMouseServiceActive = isAccessibilityServiceEnabled(
+                context, // Use the context provided to onReceive
+                MouseService::class.java.name // Get the fully qualified name of the service
+            )
+
+            // Toggle the service based on its current state
+            if (isMouseServiceActive) {
+                // If it's active, send the STOP event
+                AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Stop)
+            } else {
+                // If it's not active, send the START event
+                AppToServiceEvent.event.tryEmit(AppToServiceEvent.Event.Start)
+            }
+        }
+    }
+
+    /**
+     * Helper function to check if a specific Accessibility Service is enabled.
+     * This function is identical to the one in the previous activity, but needs to be here.
+     */
+    private fun isAccessibilityServiceEnabled(context: Context, serviceClassName: String): Boolean {
+        val accessibilityManager = context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager
+        val enabledServices = accessibilityManager.getEnabledAccessibilityServiceList(AccessibilityServiceInfo.FEEDBACK_ALL_MASK)
+
+        for (service in enabledServices) {
+            if (service.resolveInfo.serviceInfo.name == serviceClassName) {
+                return true
+            }
+        }
+        return false
+    }
+}

--- a/app/src/main/java/pl/jojczak/penmouses/ui/main/MainActivity.kt
+++ b/app/src/main/java/pl/jojczak/penmouses/ui/main/MainActivity.kt
@@ -1,5 +1,6 @@
 package pl.jojczak.penmouses.ui.main
 
+import android.content.Intent // Import Intent
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.ComponentActivity
@@ -13,6 +14,7 @@ import pl.jojczak.penmouses.service.AppToServiceEvent
 import pl.jojczak.penmouses.ui.theme.PenMouseSTheme
 import pl.jojczak.penmouses.utils.SPenManager
 import javax.inject.Inject
+import pl.jojczak.penmouses.shortcuts.EXTRA_MINIMIZE_APP // Import your constant
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
@@ -27,6 +29,27 @@ class MainActivity : ComponentActivity() {
         setContent { AppContent() }
         splashScreenHelper.startExitAnimation()
         NotificationsManager.createNotificationChannels(this)
+
+        // Use this.intent (which is a nullable Intent?)
+        handleMinimizeIntent(this.intent)
+    }
+
+    // CORRECTED SIGNATURE HERE: Making intent non-nullable to match Java API
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent) // Update the activity's current Intent
+        handleMinimizeIntent(intent) // Call new helper function
+    }
+
+    private fun handleMinimizeIntent(intent: Intent?) { // This function still accepts nullable Intent
+        Log.d(TAG, "handleMinimizeIntent called. Intent: $intent")
+        // Safely check if intent is not null and if the extra exists
+        if (intent?.getBooleanExtra(EXTRA_MINIMIZE_APP, false) == true) {
+            Log.d(TAG, "MINIMIZE_APP flag detected. Moving task to back.")
+            moveTaskToBack(true)
+        } else {
+            Log.d(TAG, "MINIMIZE_APP flag not detected.")
+        }
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
This adds a activity that instantly launches the service without using the app itself. I searched for something like this, but couldn't find it. I know the commit messages etc. aren't pretty, but maybe this will give some guys out here an idea? Wasn't planning on making a PR, but maybe someone will want this functionality.

I use this together with a custom quick tile app and now i can start it from the quick settings :)